### PR TITLE
Timecop.return rename to Timecop.returnToPresent.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Build-related information:
 
-TIMECOP_VERSION = '0.0.2'
+TIMECOP_VERSION = '0.0.2.1'
 output_path = File.expand_path("../timecop-#{TIMECOP_VERSION}.js", __FILE__)
 lib_dir = File.expand_path('../lib', __FILE__)
 lib_files = [ 'Timecop', 'MockDate', 'TimeStackItem' ].map do |file|

--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -11,7 +11,7 @@
   <script type="text/javascript" src="spec/helpers/SpecHelper.js"></script>
 
   <!-- include source files here... -->
-  <script type="text/javascript" src="timecop-0.0.1.js"></script>
+  <script type="text/javascript" src="timecop-0.0.2.1.js"></script>
 
   <!-- include spec files here... -->
   <script type="text/javascript" src="spec/MockDateSpec.js"></script>

--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
   "dependencies"  : [],
   "lib"           : ".",
   "main"          : "timecop.js",
-  "version"       : "0.0.2"
+  "version"       : "0.0.3"
 }

--- a/spec/MockDateSpec.js
+++ b/spec/MockDateSpec.js
@@ -8,7 +8,7 @@ describe('Timecop.MockDate', function() {
   });
 
   afterEach(function() {
-    Timecop.return();
+    Timecop.returnToPresent();
     Timecop.uninstall();
   });
 
@@ -33,7 +33,7 @@ describe('Timecop.MockDate', function() {
     });
 
     it('should stay in the past even after we return to the present', function() {
-      Timecop.return();
+      Timecop.returnToPresent();
       expect(date.getFullYear()).toEqual(1980);
     });
   });
@@ -47,7 +47,7 @@ describe('Timecop.MockDate', function() {
       expect(date.getFullYear()).toEqual(1838);
       Timecop.travel(1945, 5, 6);
       expect(date.getFullYear()).toEqual(1838);
-      Timecop.return();
+      Timecop.returnToPresent();
       expect(date.getFullYear()).toEqual(1838);
     });
   });

--- a/spec/TimecopSpec.js
+++ b/spec/TimecopSpec.js
@@ -5,7 +5,7 @@ describe('Timecop', function() {
   });
 
   afterEach(function() {
-    Timecop.return();
+    Timecop.returnToPresent();
     Timecop.uninstall();
   });
 
@@ -16,7 +16,7 @@ describe('Timecop', function() {
   it('should have a public API', function() {
     expect(Timecop).toHaveFunction('travel');
     expect(Timecop).toHaveFunction('freeze');
-    expect(Timecop).toHaveFunction('return');
+    expect(Timecop).toHaveFunction('returnToPresent');
     expect(Timecop).toHaveFunction('topOfStack');
     expect(Timecop).toHaveFunction('buildNativeDate');
   });
@@ -147,7 +147,7 @@ describe('Timecop', function() {
       Timecop.travel(1982, 7,  8);
       Timecop.freeze(1969, 9,  10);
       Timecop.travel(2004, 11, 12);
-      Timecop.return();
+      Timecop.returnToPresent();
       var afterReturn = new Date();
       expect(afterReturn).toBeCloseInTimeTo(beforeLeave);
     });

--- a/timecop-0.0.2.1.js
+++ b/timecop-0.0.2.1.js
@@ -1,3 +1,16 @@
+//  Timecop.js version 0.0.2.1
+//  (c) 2010 James A. Rosen, Zendesk Inc.
+//  Timecop.js is freely distributable under the MIT license.
+//  The concept and some of the structure is borrowed from Timecop,
+//  John Trupiano's Ruby gem, which can be found at
+//  https://github.com/jtrupiano/timecop. Some project structure
+//  inspired by Underscore, Jeremy Ashkenas's Javascript library for
+//  functional programming support, which can be found at
+//  https://github.com/documentcloud/underscore.
+//  For all details, documentation, and bug reports, see
+//  http://github.com/jamesarosen/Timecop.js
+
+(function(){
 // Establish the root object, `window` in the browser, or `global` on the server.
 var root = this;
 
@@ -124,3 +137,73 @@ root.Timecop = Timecop;
 
 // Export it as a V8 module, if applicable:
 if (typeof(exports) !== 'undefined') { exports._ = _; }
+
+
+// A mock Date implementation.
+Timecop.MockDate = function() {
+  if (arguments.length > 0 || !Timecop.topOfStack()) {
+    this._underlyingDate = Timecop.buildNativeDate.apply(Timecop, Array.prototype.slice.apply(arguments));
+  } else {
+    this._underlyingDate = Timecop.topOfStack().date();
+  }
+};
+
+Timecop.MockDate.prototype = {
+  getDate:            function() { return this._underlyingDate.getDate(); },
+  getDay:             function() { return this._underlyingDate.getDay(); },
+  getFullYear:        function() { return this._underlyingDate.getFullYear(); },
+  getHours:           function() { return this._underlyingDate.getHours(); },
+  getMilliseconds:    function() { return this._underlyingDate.getMilliseconds(); },
+  getMinutes:         function() { return this._underlyingDate.getMinutes(); },
+  getMonth:           function() { return this._underlyingDate.getMonth(); },
+  getSeconds:         function() { return this._underlyingDate.getSeconds(); },
+  getTime:            function() { return this._underlyingDate.getTime(); },
+  getTimezoneOffset:  function() { return this._underlyingDate.getTimezoneOffset(); },
+  getUTCDate:         function() { return this._underlyingDate.getUTCDate(); },
+  getUTCDay:          function() { return this._underlyingDate.getUTCDay(); },
+  getUTCFullYear:     function() { return this._underlyingDate.getUTCFullYear(); },
+  getUTCHours:        function() { return this._underlyingDate.getUTCHours(); },
+  getUTCMilliseconds: function() { return this._underlyingDate.getUTCMilliseconds(); },
+  getUTCMinutes:      function() { return this._underlyingDate.getUTCMinutes(); },
+  getUTCMonth:        function() { return this._underlyingDate.getUTCMonth(); },
+  getUTCSeconds:      function() { return this._underlyingDate.getUTCSeconds(); },
+  getYear:            function() { return this._underlyingDate.getYear(); },
+  toString:           function() { return this._underlyingDate.toString(); }
+};
+
+
+// A data class for carrying around 'time movement' objects.
+// Makes it easy to keep track of the time movements on a simple stack.
+Timecop.TimeStackItem = function(mockType, time) {
+  if (mockType !== 'freeze' && mockType !== 'travel') {
+    throw 'Unknown mock_type ' + mockType;
+  }
+  this.mockType = mockType;
+  this._time = time;
+  this._travelOffset = this._computeTravelOffset();
+};
+
+Timecop.TimeStackItem.prototype = {
+  date: function() {
+    return this.time();
+  },
+
+  time: function() {
+    if (this._travelOffset === null) {
+      return this._time;
+    }
+    // console.log('Now: ');
+    return new Timecop.NativeDate((new Timecop.NativeDate()).getTime() + this._travelOffset);
+  },
+
+  // @api private
+  // @return [Integer] millisecond offset traveled, if mockType is 'travel'
+  _computeTravelOffset: function() {
+    if (this.mockType === 'freeze') {
+      return null;
+    }
+    return this._time.getTime() - (new Timecop.NativeDate()).getTime();
+  }
+};
+
+})();

--- a/timecop-0.0.2.js
+++ b/timecop-0.0.2.js
@@ -57,7 +57,7 @@ var takeTrip = function(type, args) {
     try {
       fn();
     } finally {
-      Timecop.return();
+      Timecop.returnToPresent();
     }
   }
 };
@@ -122,7 +122,7 @@ var Timecop = {
   },
 
   // Pop one level off the stack.
-  return: function() {
+  returnToPresent: function() {
     timeStack.clear();
   },
 


### PR DESCRIPTION
return is a JavaScript keyword and can't be used as a method name.  
We caught this because our build was failing in IE and JSLint pointed it out to us.  This has been fixed.
Updated the package to Timecop-0.0.2.1.js.
