### PR TITLE
Add uninstall() to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,27 @@ Call `Timecop.install()` once to get started. This replaces `Date` with
 
 Travel to the morning of October 17, 2010, and allow time to continue advancing:
 
-    Timecop.travel(new Date(2010, 10, 17, 11, 45));
+``` javascript
+Timecop.travel(new Date(2010, 10, 17, 11, 45));
+```
 
 Travel to the afternoon of January 21, 2012, and keep time frozen then:
 
-    Timecop.freeze(new Date(2012, 1, 21, 14, 30))
+``` javascript
+Timecop.freeze(new Date(2012, 1, 21, 14, 30));
+```
 
 Return to the present:
 
-    Timecop.returnToPresent();
+``` javascript
+Timecop.returnToPresent();
+```
+
+Finally, to uninstall Timecop and reinstate the native Date constructor:
+
+``` javascript
+Timecop.uninstall();
+```
 
 ## Contributing ##
 


### PR DESCRIPTION
Some test/spec runners rely on the native date after specs finish executing, so calling `uninstall` becomes necessary (namely, jasmine-headless-webkit explodes otherwise). I was about to give up trying to use Timecop.js until I guessed that there was an `uninstall` function.
