### PR TITLE
MockDate should delegate toUTCString to the underlying date

### DIFF
--- a/lib/MockDate.js
+++ b/lib/MockDate.js
@@ -22,6 +22,7 @@ function defineDelegate(method) {
 }
 
 defineDelegate('toString');
+defineDelegate('toUTCString');
 defineDelegate('valueOf');
 
 var delegatedAspects = [


### PR DESCRIPTION
Ran into a need for this in my current app, figured I'd push the change upstream in case others run into it as well.
