### PR TITLE
Make Timecop an npm module

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,6 @@
 {
   "predef":    [ "module" ],
 
-  "adsafe":   false,
   "bitwise":  true,
   "newcap":   false,
   "eqeqeq":   false,
@@ -11,20 +10,15 @@
   "onevar":   false,
   "plusplus": false,
   "regexp":   false,
-  "safe":     false,
   "strict":   false,
   "undef":    true,
   "white":    false,
 
-  "cap":      false,
-  "css":      true,
   "debug":    false,
   "es5":      false,
   "evil":     false,
   "forin":    false,
-  "fragment": true,
   "laxbreak": false,
-  "on":       false,
   "sub":      false,
 
   "maxlen":    200,
@@ -33,10 +27,7 @@
   "passfail":  false,
   "browser":   true,
   "rhino":     false,
-  "windows":   false,
-  "widget":    false,
   "devel":     true,
   "lastsemic": false,
-  "newstat":   false,
   "expr":      true
 }

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source :rubygems
 
+gem 'rake'
 group :test do
   gem 'jasmine', '~> 1.1.0.rc3'
   gem 'jasmine-headless-webkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     multi_json (1.0.3)
     rack (1.3.5)
     rainbow (1.1.2)
+    rake (0.9.2.2)
     rspec (2.7.0)
       rspec-core (~> 2.7.0)
       rspec-expectations (~> 2.7.0)
@@ -47,3 +48,4 @@ PLATFORMS
 DEPENDENCIES
   jasmine (~> 1.1.0.rc3)
   jasmine-headless-webkit
+  rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,10 @@
 # Build-related information:
+require 'json'
 
 TIMECOP_VERSION = '0.1.0'
 project_root = File.expand_path(File.dirname(__FILE__))
-output_path = File.join(project_root, "timecop-#{TIMECOP_VERSION}.js")
+package_location = File.join(project_root, 'package.json')
+output_path = File.join(project_root, "timecop.js")
 lib_dir = File.join(project_root, 'lib')
 
 lib_files = [ 'Timecop', 'MockDate', 'TimeStackItem' ].map do |f|
@@ -15,14 +17,14 @@ task :default => :build
 
 desc "Delete all compiled version of the Timecop library"
 task :clean do
-  `rm timecop-*.js`
+  `rm timecop.js`
 end
 
 desc "compile, syntax-check, and test the Timecop library"
 task :build => :test
 
 desc "Run tests on the compiled Timecop library"
-task :test => :jshint do
+task :test => 'jshint:check'  do
   sh "bundle exec jasmine-headless-webkit" do |ok, res|
     fail "Test failures" unless ok
   end
@@ -30,13 +32,13 @@ task :test => :jshint do
 end
 
 namespace :jshint do
-  task :require do
+  task :require => output_path do
     sh "which jshint" do |ok, res|
       fail 'Cannot find jshint on $PATH' unless ok
     end
   end
 
-  task :check => [ 'jshint:require', output_path ] do
+  task :check => 'jshint:require' do
     config_file = File.join(project_root, '.jshintrc')
     sh "jshint #{lib_files.join(' ')} --config #{config_file}" do |ok, res|
       fail 'JSHint found errors in source.' unless ok
@@ -50,11 +52,21 @@ namespace :jshint do
   end
 end
 
-desc 'Run JSHint checks against Javascript source'
-task :jshint => 'jshint:check'
+desc "Version bump the package.json file"
+task :bump_version do
+  package = JSON.parse(File.read(package_location))
+
+  if package["version"] == TIMECOP_VERSION
+    puts("The version was not bumped")
+  else
+    package["version"] = TIMECOP_VERSION
+    File.open(package_location, 'w') {|f| f.write(JSON.pretty_generate(package)) }
+    puts("Updated the version of package.json to #{TIMECOP_VERSION}")
+  end
+end
 
 desc "compile the files in lib/ to timecop-{version}.js"
-file output_path => lib_files do
+file output_path => :bump_version do
   template = File.read(File.join(lib_dir, 'BuildTemplate.js'))
 
   contents = lib_files.
@@ -67,5 +79,5 @@ file output_path => lib_files do
 
   File.open(output_path, 'w') { |f| f.write(compiled) }
 
-  puts("Wrote #{output_path}");
+  puts("Wrote #{output_path}")
 end

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
-  "name"          : "timecop",
-  "description"   : "Time travel and freezing for Javascript tests",
-  "url"           : "http://github.com/jamesarosen/Timecop.js",
-  "keywords"      : ["util", "testing", "server", "client", "browser"],
-  "author"        : "James A. Rosen <james@zendesk.com>",
-  "contributors"  : [],
-  "dependencies"  : [],
-  "lib"           : ".",
-  "main"          : "timecop.js",
-  "version"       : "0.0.4"
+  "name": "timecop",
+  "description": "Time travel and freezing for Javascript tests",
+  "version": "0.1.0",
+  "url": "http://github.com/jamesarosen/Timecop.js",
+  "keywords": [
+    "util",
+    "testing",
+    "server",
+    "client",
+    "browser"
+  ],
+  "author": "James A. Rosen <james@zendesk.com>",
+  "main": "timecop.js"
 }

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -5,7 +5,7 @@
 #
 src_files:
   - 'spec/javascripts/support/jquery*.js'
-  - 'timecop-*.js'
+  - 'timecop.js'
 
 # stylesheets
 #

--- a/timecop.js
+++ b/timecop.js
@@ -169,6 +169,7 @@ function defineDelegate(method) {
 }
 
 defineDelegate('toString');
+defineDelegate('toUTCString');
 defineDelegate('valueOf');
 
 var delegatedAspects = [


### PR DESCRIPTION
This change was very minimal, mostly changes to the package.json since timecop.js is already exports properly.  The build task bumps versions.

To test you can either npm install from my master branch or just `require('./timecop')` in node in the root of the project.

All test pass
