### PR TITLE
`MockDate`s can be safely mutated in frozen time.

### DIFF
--- a/lib/MockDate.js
+++ b/lib/MockDate.js
@@ -5,7 +5,8 @@ Timecop.MockDate = function() {
   if (arguments.length > 0 || !Timecop.topOfStack()) {
     this._underlyingDate = Timecop.buildNativeDate.apply(Timecop, Array.prototype.slice.apply(arguments));
   } else {
-    this._underlyingDate = Timecop.topOfStack().date();
+    var date = Timecop.topOfStack().date();
+    this._underlyingDate = Timecop.buildNativeDate.call(Timecop, date.getTime());
   }
 };
 

--- a/spec/javascripts/MockDateSpec.js
+++ b/spec/javascripts/MockDateSpec.js
@@ -44,6 +44,22 @@ describe('Timecop.MockDate', function() {
     });
   });
 
+  describe("when created, and subsequently modified, while time is frozen", function() {
+    var otherDate;
+
+    beforeEach( function(){
+      Timecop.freeze(1980, 4, 29);
+      date = new Timecop.MockDate();
+      otherDate = new Timecop.MockDate();
+      date.setFullYear(1900);
+    });
+
+    it("should not modify other `Timecop.MockDate` instances created during the same trip", function() {
+      expect(date.getFullYear()).toEqual(1900);
+      expect(otherDate.getFullYear()).toEqual(1980);
+    });
+  });
+
   describe('when created with year, month, date', function() {
     beforeEach(function() {
       date = new Timecop.MockDate(1838, 8, 18, 16, 45);

--- a/timecop-0.1.1.js
+++ b/timecop-0.1.1.js
@@ -150,7 +150,8 @@ Timecop.MockDate = function() {
   if (arguments.length > 0 || !Timecop.topOfStack()) {
     this._underlyingDate = Timecop.buildNativeDate.apply(Timecop, Array.prototype.slice.apply(arguments));
   } else {
-    this._underlyingDate = Timecop.topOfStack().date();
+    var date = Timecop.topOfStack().date();
+    this._underlyingDate = Timecop.buildNativeDate.call(Timecop, date.getTime());
   }
 };
 


### PR DESCRIPTION
Previously multiple instances would share the same underlying date object.

This makes it easier to use timecop.js and moment.js together.
