### PR TITLE
toLocaleDateString() results in "Method invoked on an object that is not Date" error in Chrome

### DIFF
--- a/lib/MockDate.js
+++ b/lib/MockDate.js
@@ -30,7 +30,10 @@ Timecop.MockDate.prototype = {};
 // passing all arguments and returning the result.
 function defineDelegate(method) {
   Timecop.MockDate.prototype[method] = function() {
-    return this._underlyingDate[method].apply(this._underlyingDate, arguments);
+    Timecop.uninstall();
+    var returnVal = this._underlyingDate[method].apply(this._underlyingDate, arguments);
+    Timecop.install();
+    return returnVal;
   };
 }
 


### PR DESCRIPTION
After calling Timecop.install and Timecop.travel, when I then call `toLocaleDateString()` on any date object, I get this error:

```
(new Date).toLocaleDateString()
TypeError: Method invoked on an object that is not Date.

(new Date).toLocaleTimeString()
TypeError: Method invoked on an object that is not Date.
```

The backtrace is:

```
toLocaleDateTime v8/i18n:1107
Object.defineProperty.value v8/i18n:1132
Timecop.MockDate.(anonymous function) timecop.js:173
```

You can where the error is defined in the V8 source code [here](https://code.google.com/p/v8/source/browse/branches/bleeding_edge/src/extensions/i18n/overrides.js):

``` javascript
function toLocaleDateTime(date, locales, options, required, defaults, service) {
  if (!(date instanceof Date)) {
    throw new TypeError('Method invoked on an object that is not Date.');
  }
  ...
```

I don't understand it completely, but it looks like even though we called the `toLocaleDateTime` method on an actual native `Date` object (`this._underlyingDate`), the way `toLocaleDateTime` is defined (`Object.defineProperty(Date.prototype, 'toLocaleDateString',...`), it ends up calling `toLocaleDateTime` with a non-native Date object (presumably a `Timecop.MockDate object`) as the first argument. Hence my proposed workaround in the attached pull request...

I'm using Chromium Version 28.0.1500.52 Ubuntu 12.04 (28.0.1500.52-0ubuntu1.12.04.2).
