### PR TITLE
New build for Date.now()

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     coffee-script (2.2.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.1.3)
+    coffee-script-source (1.7.0)
     diff-lcs (1.1.3)
     execjs (1.2.9)
       multi_json (~> 1.0)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {},
   "lib": ".",
   "main": "timecop.js",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "devDependencies": {
     "jshint": "~1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "timecop",
   "description": "Time travel and freezing for Javascript tests",
   "url": "http://github.com/jamesarosen/Timecop.js",
+  "repository": "https://github.com/jamesarosen/Timecop.js.git",
   "keywords": [
     "util",
     "testing",
@@ -11,7 +12,7 @@
   ],
   "author": "James A. Rosen <james.a.rosen@gmail.com>",
   "contributors": [],
-  "dependencies": [],
+  "dependencies": {},
   "lib": ".",
   "main": "timecop.js",
   "version": "0.1.1",

--- a/timecop.js
+++ b/timecop.js
@@ -1,4 +1,4 @@
-//  Timecop.js version 0.1.1
+//  Timecop.js version 0.2.0
 //  (c) 2010 James A. Rosen, Zendesk Inc.
 //  Timecop.js is freely distributable under the MIT license.
 //  The concept and some of the structure is borrowed from Timecop,
@@ -162,6 +162,12 @@ Timecop.MockDate.UTC = function() {
 Timecop.MockDate.parse = function(dateString) {
   return Timecop.NativeDate.parse(dateString);
 };
+
+if (Timecop.NativeDate.hasOwnProperty('now')) {
+  Timecop.MockDate.now = function() {
+    return new Timecop.MockDate().getTime();
+  };
+}
 
 Timecop.MockDate.prototype = {};
 


### PR DESCRIPTION
You mentioned in pull #22 that you were going to create a 0.2.0 release, but never did. This request includes the commits I needed make `rake test` and `rake dist` work, plus the tag, build file, etc. for 0.2.0. Thanks for the great library!
